### PR TITLE
Group the event store storage by Bounded Context

### DIFF
--- a/.agents/tasks/event-store-context-prefix.md
+++ b/.agents/tasks/event-store-context-prefix.md
@@ -1,0 +1,203 @@
+# Per-context isolation for `EventStore` persistence
+
+## Status
+
+Investigation complete; verified against `jdbc-storage` and `gcloud-jvm` (Datastore).
+Implementation not started.
+
+## Problem
+
+All Bounded Contexts of an application share one `StorageFactory`
+(`ServerEnvironment.instance().storageFactory()`). `EventBus.registerWith(context)` calls
+`StorageFactory.createEventStore(context.spec())`, which builds
+`new DefaultEventStore(context, factory)`. The Java objects are per-context, but
+`DefaultEventStore` creates its record storage as:
+
+```java
+factory.createRecordStorage(context, spec())   // group == null
+```
+
+with `RecordSpec(idType = EventId, recordType = Event)`, so `sourceType == recordType == Event`.
+
+`jdbc-storage` derives the physical table identity solely from
+`(sourceType, recordType, group)` — see `TableSpecs.SpecKey` and `TableSpecs.tableName(..)`.
+`ContextSpec` is accepted by `JdbcRecordStorage` but never participates in table naming.
+For the ungrouped event-store spec the name is `TableNames.of(Event.class)` =
+**`spine_core_Event`** — one table shared by every Bounded Context of the application
+(and by any System context with `SystemSettings.persistEvents()` enabled).
+
+`InMemoryStorageFactory` is unaffected only by accident: every `createRecordStorage(..)`
+call returns a fresh `InMemoryRecordStorage` with its own data map, so contexts are
+isolated by object identity. This is why tests never catch the issue.
+
+`gcloud-jvm` (Datastore) has the same flaw. `DatastoreStorageFactory` does not override
+`createEventStore`, and for an ungrouped storage the Entity kind defaults to
+`FlatLayout(domainType)` → the qualified type name, **`spine.core.Event`**, for every
+context (`RecordLayouts.find(Class)` → `RecordLayout(Class)` → `Kind.of(domainType)`).
+Datastore namespaces do not help: they serve multitenancy — the namespace comes from
+the current tenant or the deployment-wide default — and `wrapperFor(context)` consults
+only `isMultitenant()`, never the context name.
+
+### Consequences (multi-context apps on JDBC or Datastore)
+
+- Events of all contexts intermingle in one physical store — the `spine_core_Event`
+  table / kind.
+- `CatchUpProcess` reads via `context.eventBus().eventStore()` with an `EventStreamQuery`
+  filtered by the `type` column. If two contexts use the same event proto type
+  (shared event definitions), catch-up in one context replays the other context's events.
+- Unfiltered `EventStore.read(..)` (replay/export tooling) returns foreign events.
+- No physical boundary for per-context data lifecycle (deletion, GDPR erasure, backup).
+
+## Fix scenario
+
+### 1. core-jvm: group the event store by context
+
+`DefaultEventStore` passes a `StorageGroup` derived from the context name:
+
+```java
+public DefaultEventStore(ContextSpec context, StorageFactory factory) {
+    super(context, factory.createRecordStorage(context, spec(), groupOf(context)));
+    ...
+}
+
+private static StorageGroup groupOf(ContextSpec context) {
+    return new StorageGroup(context.name().getValue());
+}
+```
+
+Rationale:
+
+- `StorageGroup`'s documented purpose is exactly this: differentiating storages holding
+  records of the same type, so a vendor mapping equal record specs to one physical storage
+  does not conflate them.
+- Fixes both group-honoring SPI implementations at once, with no backend changes for
+  the core behavior:
+    - `jdbc-storage` names the table via the existing `TableNames.of(Event.class, group)`
+      → `Billing_Event` (System contexts → `Billing_System_Event`);
+    - `gcloud-jvm` names the kind via `Kind.of(Event.class, group)` → `Billing-Event`
+      (verified: `createRecordStorage` with a non-null group routes to
+      `RecordLayouts.find(recordType, group)`, defaulting to a flat layout under the
+      grouped kind; the dash separator is documented as collision-proof against
+      type-name-derived kinds).
+- `InMemoryStorageFactory` deliberately ignores the group → no behavior change in-memory.
+- `TableSpecs` cache is keyed by `SpecKey` including the group name → per-context entries
+  appear naturally.
+
+Add `StorageGroup.of(BoundedContextName)` next to the existing
+`StorageGroup.of(entityClass)` factory method, as the single source of truth for
+deriving a group from a context. `DefaultEventStore` calls it with `context.name()`;
+the jdbc-storage Builder overload (step 3) uses the same helper, so the two sides
+can never drift apart in how the group name is spelled.
+
+### 2. jdbc-storage: sanitize group names for SQL
+
+Context names are validated only as non-blank (`BoundedContextNames.checkValid`), so they
+may contain spaces, dashes, etc. `TableNames.of(recordType, group)` replaces only dots.
+Extend sanitization to replace any character outside `[A-Za-z0-9_]` with `_`.
+
+### 3. jdbc-storage: custom-name API for context-grouped tables
+
+Today the event table can be renamed via `TableSpecs.Builder.setTableName(Event.class, ..)`
+(single-type lookup by `sourceType`). Once the event storage is grouped, that lookup no
+longer applies, and grouped custom names are registered by *entity state type* only.
+Add an overload addressing the table by the context it belongs to:
+
+```java
+Builder setTableName(BoundedContextName context, Class<R> recordType, String name)
+```
+
+`BoundedContextName` rather than a raw `String`, because:
+
+- The type states what the parameter is; the name shortens to just `context`.
+- `setTableName(String, Class, String)` would put two `String`s of different meaning
+  in one signature — transposing the context name and the table name would compile.
+- Users obtain the value via `BoundedContextNames.newName(..)`, which validates it,
+  so a blank name fails at configuration time, not at table-creation time.
+- It mirrors the existing `setTableName(Class<S> stateType, ..)` overload: the Builder
+  accepts the *typed identity* of the group owner and derives the group-name string
+  internally (via `StorageGroup.of(BoundedContextName)` from step 1). The `String`
+  representation of a group stays an implementation detail of `TableSpecs`.
+
+Note: to address a *System* context's event table, users spell the name directly
+(`newName("Billing_System")`), since `BoundedContextName.toSystem()` is `@Internal`.
+Mention this in the overload's Javadoc.
+
+Release note: existing `setTableName(Event.class, ..)` customizations stop applying to
+the event table.
+
+### 4. gcloud-jvm: layout API for context-grouped kinds
+
+Mirrors step 3. Grouped record layouts are registered via
+`Builder.organizeRecords(Class<S> stateType, Class<R> recordType, RecordLayout)` —
+keyed by entity state type, so a context-grouped kind cannot be addressed.
+Add an overload:
+
+```java
+Builder organizeRecords(BoundedContextName context,
+                        Class<R> recordType,
+                        RecordLayout<I, R> layout)
+```
+
+deriving the group via `StorageGroup.of(BoundedContextName)` from step 1
+(same rationale as the typed parameter in step 3).
+
+No name sanitization is needed (unlike step 2): Datastore kinds are arbitrary UTF-8
+strings, and the existing guard in `Kind` (no `__` prefix) covers the corner case.
+
+Release note: `createRecordStorage` deliberately bypasses single-type configuration
+for grouped storages, so existing `useRecordStorage(EventId.class, Event.class, ..)`
+and single-type `organizeRecords(Event.class, ..)` registrations stop applying to
+the event storage once it becomes grouped.
+
+### 5. Migration for existing deployments
+
+Existing data sits in `spine_core_Event` with no per-row context discriminator (that is
+the root cause). The `type` column holds the qualified proto type name, so operators can
+split by SQL using each context's event-type set:
+
+```sql
+INSERT INTO Billing_Event
+    SELECT * FROM spine_core_Event
+    WHERE type IN ('example.billing.InvoiceIssued', ...);
+```
+
+For Datastore, events live under the kind `spine.core.Event` (per namespace, for
+multi-tenant apps). Migration is a copy of entities to the `<Context>-Event` kind,
+split by the same `type` property (the event columns are storage-agnostic) — a small
+utility or a Dataflow job; iterate namespaces for multi-tenant deployments.
+
+Document in release notes. Decide: clean break (2.0 is SNAPSHOT) vs. an opt-out flag on
+the storage factory builders (`JdbcStorageFactory`, `DatastoreStorageFactory`) for the
+legacy shared table / kind.
+
+### 6. Tests
+
+- core-jvm: assert `createEventStore` passes the context-derived group
+  (extend `MemoizingStorageFactory` in `server` testFixtures).
+- jdbc-storage: integration test — two `BoundedContext`s over one `JdbcStorageFactory`
+  (H2), distinct events posted in each; assert each context's `EventStore.read(..)`
+  returns only its own events. Unit test for the `<ContextName>_Event` naming.
+- gcloud-jvm: the same two-context test over one `DatastoreStorageFactory`
+  (`TestDatastoreStorageFactory` from `testlib`, backed by the local emulator);
+  unit test for the `Billing-Event` kind.
+
+## Rejected alternative
+
+Fixing only inside jdbc-storage by mixing `ContextSpec` into `SpecKey`/table names:
+
+- prefixing all ungrouped tables renames every entity-state table (large migration blast
+  radius) and breaks `MirrorStorage`, whose table must match the Spine 1.x layout;
+- special-casing `Event` in one backend leaves other SPI implementations broken.
+
+## Related follow-up (out of scope)
+
+Entity-scoped storages derive their identity from the entity state type alone:
+`EntityRecordStorage` is ungrouped and named by the state type, while
+`EntityEventStorage` and `EntityStateHistoryStorage` are grouped by it. If one entity
+class — or two classes sharing a state type — were registered in two contexts of the
+same application, those storages would collide across contexts exactly like the event
+store does. Unlike the event-store collision, which hits every multi-context app
+unconditionally, this one needs a shared entity type — rare, and arguably a modeling
+error. The same fix shape (a context-derived component in the group) would apply, but
+it renames every entity table / kind — a far larger migration — so it stays out of
+scope here.

--- a/.agents/tasks/event-store-context-prefix.md
+++ b/.agents/tasks/event-store-context-prefix.md
@@ -3,7 +3,11 @@
 ## Status
 
 Investigation complete; verified against `jdbc-storage` and `gcloud-jvm` (Datastore).
-Implementation not started.
+
+Step 1 (core-jvm) implemented: `StorageGroup.of(BoundedContextName)` added,
+`DefaultEventStore` passes the context-derived group; covered by
+`EventStoreIdentitySpec` and `StorageGroupSpec`. Steps 2–4 (`jdbc-storage`,
+`gcloud-jvm`) and the migration/release notes are pending.
 
 ## Problem
 

--- a/.agents/tasks/event-store-context-prefix.md
+++ b/.agents/tasks/event-store-context-prefix.md
@@ -93,11 +93,26 @@ deriving a group from a context. `DefaultEventStore` calls it with `context.name
 the jdbc-storage Builder overload (step 3) uses the same helper, so the two sides
 can never drift apart in how the group name is spelled.
 
-### 2. jdbc-storage: sanitize group names for SQL
+### 2. jdbc-storage: collision-free group names in table names
 
-Context names are validated only as non-blank (`BoundedContextNames.checkValid`), so they
-may contain spaces, dashes, etc. `TableNames.of(recordType, group)` replaces only dots.
-Extend sanitization to replace any character outside `[A-Za-z0-9_]` with `_`.
+Context names are validated only as non-blank (`BoundedContextNames.checkValid`), so
+they may contain spaces, dots, dashes, etc. `TableNames.of(recordType, group)` replaces
+only dots with `_`, which both fails for other illegal characters and aliases distinct
+names: `Sales.EU` and `Sales_EU` collapse into one `Sales_EU_Event` table (flagged by
+the Codex review on PR #1673). The same aliasing already affects entity-state groups
+whose proto type names contain underscores.
+
+Make the mapping injective without renaming the common case. Names built solely of
+letters, digits, and dots — the vast majority: qualified proto type names without
+underscores, plain context names — keep today's dots-to-`_` mapping and their existing
+tables. A name containing `_` or any other character is exactly the class that can
+alias after that mapping; for those, replace illegal characters and append a short
+fixed-length digest of the raw name (with a distinguishing marker, e.g. `_h<hex>`).
+This renames the existing tables only of underscore-bearing proto type names — already
+ambiguous today — which the migration notes must call out. A full escape scheme
+(`_` → `__`, `.` → `_d`, ...) was considered and rejected: it renames every existing
+dotted-name table. Datastore (`gcloud-jvm`) needs none of this: kinds keep the raw
+name. `StorageGroup`'s KDoc now states the injective-mapping requirement for vendors.
 
 ### 3. jdbc-storage: custom-name API for context-grouped tables
 

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.530`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.540`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1120,14 +1120,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using 
+This report was generated on **Thu Aug 27 00:27:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.530`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.540`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2343,14 +2343,14 @@ This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using 
+This report was generated on **Thu Aug 27 00:27:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.530`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.540`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3406,14 +3406,14 @@ This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using 
+This report was generated on **Thu Aug 27 00:27:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.530`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.540`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4487,14 +4487,14 @@ This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using 
+This report was generated on **Thu Aug 27 00:27:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.530`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.540`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5626,14 +5626,14 @@ This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using 
+This report was generated on **Thu Aug 27 00:27:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.530`
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.540`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6841,14 +6841,14 @@ This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using 
+This report was generated on **Thu Aug 27 00:27:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.530`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.540`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -8116,6 +8116,6 @@ This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 26 18:11:18 WEST 2026** using 
+This report was generated on **Thu Aug 27 00:27:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.530</version>
+<version>2.0.0-SNAPSHOT.540</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/event/store/DefaultEventStore.java
+++ b/server/src/main/java/io/spine/server/event/store/DefaultEventStore.java
@@ -39,6 +39,7 @@ import io.spine.server.storage.MessageStorage;
 import io.spine.server.storage.RecordSpec;
 import io.spine.server.storage.RecordWithColumns;
 import io.spine.server.storage.StorageFactory;
+import io.spine.server.storage.StorageGroup;
 import io.spine.server.tenant.EventOperation;
 import io.spine.server.tenant.TenantAwareOperation;
 
@@ -57,6 +58,13 @@ import static java.util.stream.Collectors.toSet;
 
 /**
  * Default implementation of {@link EventStore}.
+ *
+ * <p>The underlying record storage belongs to a {@link StorageGroup} named after
+ * the Bounded Context. The event stores of all contexts of an application store
+ * records of the same type, so the group is what keeps the event log of each
+ * context in its own physical storage — a table, a kind, and the like — in
+ * a storage vendor which otherwise maps equal record specifications to one
+ * physical storage.
  */
 public final class DefaultEventStore extends MessageStorage<EventId, Event>
         implements EventStore, WithLogging {
@@ -72,7 +80,7 @@ public final class DefaultEventStore extends MessageStorage<EventId, Event>
      * Constructs a new instance.
      */
     public DefaultEventStore(ContextSpec context, StorageFactory factory) {
-        super(context, factory.createRecordStorage(context, spec()));
+        super(context, factory.createRecordStorage(context, spec(), groupOf(context)));
         this.log = new Log();
     }
 
@@ -80,6 +88,10 @@ public final class DefaultEventStore extends MessageStorage<EventId, Event>
         var spec = new RecordSpec<>(EventId.class, Event.class, Signal::id,
                                     EventColumn.definitions());
         return spec;
+    }
+
+    private static StorageGroup groupOf(ContextSpec context) {
+        return StorageGroup.of(context.name());
     }
 
     private static void ensureSameTenant(ImmutableList<Event> events) {

--- a/server/src/main/java/io/spine/server/event/store/DefaultEventStore.java
+++ b/server/src/main/java/io/spine/server/event/store/DefaultEventStore.java
@@ -63,7 +63,7 @@ import static java.util.stream.Collectors.toSet;
  * the Bounded Context. The event stores of all contexts of an application store
  * records of the same type, so the group is what keeps the event log of each
  * context in its own physical storage — a table, a kind, and the like — in
- * a storage vendor which otherwise maps equal record specifications to one
+ * a storage vendor that otherwise maps equal record specifications to one
  * physical storage.
  */
 public final class DefaultEventStore extends MessageStorage<EventId, Event>

--- a/server/src/main/kotlin/io/spine/server/storage/StorageGroup.kt
+++ b/server/src/main/kotlin/io/spine/server/storage/StorageGroup.kt
@@ -44,6 +44,12 @@ import io.spine.type.TypeName
  * A `StorageGroup` provides that distinction, so each group is allocated
  * its own physical storage — a table, a kind, and the like.
  *
+ * Distinct group names denote distinct physical storages. A vendor that
+ * normalizes the name to satisfy its own naming rules — for example,
+ * replacing the characters not allowed in SQL identifiers — must keep
+ * that mapping collision-free, so that no two group names resolve to
+ * one physical storage.
+ *
  * The [name] is assigned by the party creating the storage: a repository
  * names the per-entity histories after the entity state, and the event
  * store of a Bounded Context is named after the context — see the [of]

--- a/server/src/main/kotlin/io/spine/server/storage/StorageGroup.kt
+++ b/server/src/main/kotlin/io/spine/server/storage/StorageGroup.kt
@@ -83,6 +83,11 @@ public data class StorageGroup(public val name: String) {
          * records of the same type, so this group is what keeps the event
          * log of each context in its own physical storage.
          *
+         * The context name is taken verbatim. Mapping it to the name of
+         * a physical storage — including any normalization a vendor's
+         * naming rules require — is the vendor's concern, as described
+         * in the class documentation.
+         *
          * @param context The name of the Bounded Context served by the storage.
          */
         @JvmStatic

--- a/server/src/main/kotlin/io/spine/server/storage/StorageGroup.kt
+++ b/server/src/main/kotlin/io/spine/server/storage/StorageGroup.kt
@@ -27,6 +27,7 @@
 package io.spine.server.storage
 
 import io.spine.base.EntityState
+import io.spine.core.BoundedContextName
 import io.spine.server.entity.Entity
 import io.spine.server.entity.model.EntityClass
 import io.spine.type.TypeName
@@ -35,16 +36,19 @@ import io.spine.type.TypeName
  * A named group differentiating the record storages that hold records of
  * the same type.
  *
- * Several storages of a Bounded Context may store records of one type. For
- * example, the latest state of an entity and the history of its past states
- * are both stored as `EntityRecord`s. Without a further distinction, a storage
- * vendor mapping equal record specifications to one physical storage would
- * conflate them. A `StorageGroup` provides that distinction, so each group is
- * allocated its own physical storage — a table, a kind, and the like.
+ * Several storages may store records of one type. For example, the latest
+ * state of an entity and the history of its past states are both stored as
+ * `EntityRecord`s, and the event stores of all Bounded Contexts store
+ * `Event`s. Without a further distinction, a storage vendor mapping equal
+ * record specifications to one physical storage would conflate them.
+ * A `StorageGroup` provides that distinction, so each group is allocated
+ * its own physical storage — a table, a kind, and the like.
  *
- * The [name] is assigned by the repository creating the storage — typically
- * after the entity state, via [of]. Choosing the value is the repository's
- * decision; this type only carries it.
+ * The [name] is assigned by the party creating the storage: a repository
+ * names the per-entity histories after the entity state, and the event
+ * store of a Bounded Context is named after the context — see the [of]
+ * overloads. Choosing the value is that party's decision; this type only
+ * carries it.
  *
  * @property name The name of the storage group.
  */
@@ -64,5 +68,19 @@ public data class StorageGroup(public val name: String) {
             val name = TypeName.of(stateClass).value()
             return StorageGroup(name)
         }
+
+        /**
+         * Creates a group for the event store of the Bounded Context with
+         * the given name.
+         *
+         * The event stores of all Bounded Contexts of an application store
+         * records of the same type, so this group is what keeps the event
+         * log of each context in its own physical storage.
+         *
+         * @param context The name of the Bounded Context served by the storage.
+         */
+        @JvmStatic
+        public fun of(context: BoundedContextName): StorageGroup =
+            StorageGroup(context.value)
     }
 }

--- a/server/src/test/kotlin/io/spine/server/entity/storage/HistoryStorageIdentitySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/storage/HistoryStorageIdentitySpec.kt
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.Test
  * different entity types stay apart, and the two histories of one entity
  * stay apart by their record type. The latest-state records of the entity
  * arrive at the same seam belonging to no group. In-memory storages are
- * isolated per instance and cannot observe a shared table, hence the
+ * isolated per instance and cannot observe a shared table; hence, the
  * assertions capture the groups and specifications at the vendor seam.
  */
 @DisplayName("Per-entity history storages should")

--- a/server/src/test/kotlin/io/spine/server/event/store/EventStoreIdentitySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/event/store/EventStoreIdentitySpec.kt
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test
  * of all contexts store records of the same type, so the group, named
  * after the context, is what keeps the event log of each context in its
  * own physical storage. In-memory storages are isolated per instance and
- * cannot observe a shared table, hence the assertions capture the
+ * cannot observe a shared table; hence, the assertions capture the
  * identities at the vendor seam.
  */
 @DisplayName("Event stores of Bounded Contexts should")

--- a/server/src/test/kotlin/io/spine/server/event/store/EventStoreIdentitySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/event/store/EventStoreIdentitySpec.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.event.store
+
+import com.google.protobuf.Message
+import io.kotest.matchers.collections.shouldContainExactly
+import io.spine.core.Event
+import io.spine.server.ContextSpec
+import io.spine.server.storage.RecordSpec
+import io.spine.server.storage.RecordStorage
+import io.spine.server.storage.StorageFactory
+import io.spine.server.storage.StorageGroup
+import io.spine.server.storage.memory.InMemoryStorageFactory
+import io.spine.server.storage.system.SystemAwareStorageFactory
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies the physical identity of the event stores of Bounded Contexts.
+ *
+ * The event store of each context reaches a storage vendor at the
+ * [StorageFactory.createRecordStorage] seam, where the vendor allocates
+ * the physical storage — a table, a kind — by the ([group][StorageGroup],
+ * [recordType][RecordSpec.recordType]) pair it receives. The event stores
+ * of all contexts store records of the same type, so the group, named
+ * after the context, is what keeps the event log of each context in its
+ * own physical storage. In-memory storages are isolated per instance and
+ * cannot observe a shared table, hence the assertions capture the
+ * identities at the vendor seam.
+ */
+@DisplayName("Event stores of Bounded Contexts should")
+internal class EventStoreIdentitySpec {
+
+    @Test
+    fun `belong to a storage group named after their context`() {
+        val factory = GroupRecordingFactory()
+        val context = ContextSpec.singleTenant("Billing")
+
+        factory.createEventStore(context)
+
+        factory.eventStoreIdentities() shouldContainExactly listOf(
+            StorageGroup("Billing") to Event::class.java
+        )
+    }
+
+    @Test
+    fun `give two contexts two separate event logs`() {
+        val factory = GroupRecordingFactory()
+
+        factory.createEventStore(ContextSpec.singleTenant("Billing"))
+        factory.createEventStore(ContextSpec.singleTenant("Shipping"))
+
+        factory.eventStoreIdentities() shouldContainExactly listOf(
+            StorageGroup("Billing") to Event::class.java,
+            StorageGroup("Shipping") to Event::class.java
+        )
+    }
+
+    @Test
+    fun `reach the vendor seam through the system-aware wrapper of the framework`() {
+        val vendor = GroupRecordingFactory()
+        val wrapped = SystemAwareStorageFactory.wrap(vendor)
+        val context = ContextSpec.singleTenant("Billing")
+
+        wrapped.createEventStore(context)
+
+        // The framework always interacts with the wrapper; the group of
+        // the event store must reach the wrapped vendor factory intact.
+        vendor.eventStoreIdentities() shouldContainExactly listOf(
+            StorageGroup("Billing") to Event::class.java
+        )
+    }
+
+    /**
+     * A [StorageFactory] capturing the groups and the record specifications
+     * handed to the vendor seam, delegating the actual storage to
+     * the in-memory factory.
+     */
+    private class GroupRecordingFactory : StorageFactory {
+
+        private val delegate = InMemoryStorageFactory.newInstance()
+        private val creations = mutableListOf<Pair<StorageGroup?, RecordSpec<*, *>>>()
+
+        override fun <I : Any, R : Message> createRecordStorage(
+            context: ContextSpec,
+            recordSpec: RecordSpec<I, R>,
+            group: StorageGroup?
+        ): RecordStorage<I, R> {
+            creations.add(group to recordSpec)
+            return delegate.createRecordStorage(context, recordSpec, group)
+        }
+
+        /**
+         * Returns the identities — the `(group, recordType)` pairs — of
+         * the created grouped storages, in the order of storage creation.
+         */
+        fun eventStoreIdentities(): List<Pair<StorageGroup, Class<*>>> =
+            creations.mapNotNull { (group, spec) ->
+                group?.let { it to spec.recordType() }
+            }
+
+        override fun isOpen(): Boolean = delegate.isOpen
+
+        override fun close() = delegate.close()
+    }
+}

--- a/server/src/test/kotlin/io/spine/server/storage/StorageGroupSpec.kt
+++ b/server/src/test/kotlin/io/spine/server/storage/StorageGroupSpec.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage
+
+import io.kotest.matchers.shouldBe
+import io.spine.core.BoundedContextNames.newName
+import io.spine.server.aggregate.given.aggregate.TestAggregate
+import io.spine.test.aggregate.AggProject
+import io.spine.testing.ClassTest
+import io.spine.type.TypeName
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`StorageGroup` should")
+internal class StorageGroupSpec : ClassTest<StorageGroup>(StorageGroup::class.java) {
+
+    @Test
+    fun `create a group for an entity class, named after its state type`() {
+        StorageGroup.of(TestAggregate::class.java) shouldBe
+                StorageGroup(TypeName.of(AggProject::class.java).value())
+    }
+
+    @Test
+    fun `create a group for a Bounded Context, named after it`() {
+        StorageGroup.of(newName("Billing")) shouldBe StorageGroup("Billing")
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.530")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.540")


### PR DESCRIPTION
This PR makes the event store of each Bounded Context land in its own physical
storage when the application runs on a storage backend which keys physical
storages by the record specification, such as `jdbc-storage` or `gcloud-jvm`.

## Problem

All Bounded Contexts of an application share one `StorageFactory`.
`DefaultEventStore` created its record storage with **no `StorageGroup`**, and
its record specification is the same for every context (`EventId` → `Event`).
Backends deriving the physical storage identity from the specification alone
therefore put the events of *all* contexts into one table
(`spine_core_Event` in `jdbc-storage`) or one Datastore kind
(`spine.core.Event` in `gcloud-jvm`):

- events of all contexts (plus System contexts with `persistEvents()`)
  intermingle in one physical store;
- `CatchUpProcess` reads via `EventStore.read(..)` filtered by event type —
  when two contexts share an event proto type, catch-up in one context replays
  the events of the other;
- there is no physical boundary for per-context data lifecycle.

`InMemoryStorageFactory` is unaffected only by accident: each
`createRecordStorage(..)` call returns a fresh, instance-isolated storage.
This is why tests never caught the issue.

## Fix

`DefaultEventStore` now creates its record storage under a `StorageGroup`
named after the Bounded Context, via the new
`StorageGroup.of(BoundedContextName)` factory:

- `StorageGroup`'s documented purpose is exactly this: differentiating
  storages holding records of the same type, so a vendor does not conflate
  them — per-entity histories already use it.
- Both group-honoring backends are fixed with **no backend changes**:
  `jdbc-storage` derives the `Billing_Event` table, `gcloud-jvm` the
  `Billing-Event` kind, through their existing grouped-naming paths.
- `InMemoryStorageFactory` ignores groups — no behavior change in tests.

The follow-up work in `jdbc-storage` and `gcloud-jvm` (custom-name /
custom-layout API for context-grouped storages, migration notes) is planned in
[`.agents/tasks/event-store-context-prefix.md`](https://github.com/SpineEventEngine/core-jvm/blob/event-store-context-prefix/.agents/tasks/event-store-context-prefix.md)
and will be addressed in separate PRs after this one lands.

## Migration note (release notes material)

On group-honoring backends the event log moves to a new per-context physical
storage. Existing deployments keep their data in the old shared storage
(`spine_core_Event` / kind `spine.core.Event`); operators split it by the
`type` column/property using each context's event-type set. Detailed guidance
is part of the planned `jdbc-storage` / `gcloud-jvm` follow-ups.

## Testing

- New `EventStoreIdentitySpec` asserts, at the `createRecordStorage(..)`
  vendor seam, that the event store arrives with the `(group, recordType)`
  identity `(<context name>, Event)`, that two contexts produce two distinct
  identities, and that the group passes through `SystemAwareStorageFactory`
  intact.
- New `StorageGroupSpec` (a `ClassTest`) covers both `of(..)` factories and
  null-checks the static API.
- Full `./gradlew build dokkaGenerate` passes locally, including the
  behavioral `InMemoryDefaultEventStoreTest` and the delivery/catch-up suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
